### PR TITLE
feat(proxy): Set the default connection timeout to 10 seconds

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,9 @@ pub struct BootArgs {
     /// Concurrent connections
     #[clap(short, long, default_value = "1024")]
     concurrent: usize,
+    /// Connection timeout
+    #[clap(short = 'T', long, default_value = "10")]
+    connect_timeout: u64,
     /// IP addresses whitelist, e.g. 47.253.53.46,47.253.81.245
     #[clap(short, long, value_parser, value_delimiter = ',')]
     whitelist: Vec<std::net::IpAddr>,

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -56,7 +56,7 @@ pub async fn run(args: BootArgs) -> crate::Result<()> {
         concurrent: args.concurrent,
         auth,
         whitelist: args.whitelist,
-        connector: connect::Connector::new(args.cidr, args.fallback),
+        connector: connect::Connector::new(args.cidr, args.fallback, args.connect_timeout),
     };
 
     match args.proxy {

--- a/src/proxy/socks5/server/connection/connect.rs
+++ b/src/proxy/socks5/server/connection/connect.rs
@@ -15,8 +15,8 @@ use tokio::{
 
 /// Socks5 connection type `Connect`
 ///
-/// This connection can be used as a regular async TCP stream after replying to the
-/// client.
+/// This connection can be used as a regular async TCP stream after replying to
+/// the client.
 #[derive(Debug)]
 pub struct Connect<S> {
     stream: TcpStream,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `connect_timeout` option for configuring connection timeouts with a default value of 10 seconds.

- **Improvements**
  - Enhanced connection handling to support timeouts, improving stability and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->