### PR TITLE
deps(nix): bump version to 0.29.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ futures = "0.3.30"
 
 [target.'cfg(target_family = "unix")'.dependencies]
 daemonize = "0.5.0"
-nix = { version = "0.28.0", features = ["user", "signal"] }
+nix = { version = "0.29.0", features = ["user", "signal"] }
 sysinfo = { version = "0.30", default-features = false }
 
 [features]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the `nix` dependency from version `0.28.0` to `0.29.0` for improved performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->