### PR TITLE
add Fixed Subnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,13 @@ while true; do curl -x http://127.0.0.1:8100 -s https://api.ip.sb/ip -A Mozilla;
 2001:470:e953:f1d7:eb68:cc59:b2d0:2c6f
 
 ```
-
+Example with Fixed Subnet
+To run the server with a fixed subnet, use the --fixed-subnet-48 option:
+  
+```shell
+# Run the server http/socks5 with fixed subnet
+vproxy run -i 2001:470:e953::/48 --fixed-subnet-48 2001:4/48 http
+```
 ## Manual
 
 If no subnet is configured, the local default network proxy request will be used. When the local machine sets the priority `Ipv4`/`Ipv6` and the priority is `Ipv4`, it will always use `Ipv4` to make requests (if any).

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ To run the server with a fixed subnet, use the --fixed-subnet-48 option:
   
 ```shell
 # Run the server http/socks5 with fixed subnet
-vproxy run -i 2001:470:e953::/48 --fixed-subnet-48 2001:4/48 http
+vproxy run -i 2001:470:e953::/48 --fixed-subnet-48 2001:470:e953::/48 http
 ```
 ## Manual
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,6 +91,9 @@ pub struct BootArgs {
     /// Fallback address
     #[clap(short, long)]
     fallback: Option<std::net::IpAddr>,
+    /// Fixed /48 subnet
+    #[clap(short = 's', long)]
+    fixed_subnet_48: Option<cidr::Ipv6Cidr>, 
 
     #[clap(subcommand)]
     proxy: Proxy,

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -13,21 +13,16 @@ use std::net::{IpAddr, SocketAddr};
 use tracing::Level;
 use tracing_subscriber::{EnvFilter, FmtSubscriber};
 
-struct ProxyContext {
-    /// Bind address
+pub struct ProxyContext {
     pub bind: SocketAddr,
-    /// Number of concurrent connections
     pub concurrent: usize,
-    /// Authentication type
     pub auth: AuthMode,
-    /// Ip whitelist
     pub whitelist: Vec<IpAddr>,
-    /// Connector
     pub connector: Connector,
 }
 
+
 pub fn run(args: BootArgs) -> crate::Result<()> {
-    // Initialize the logger with a filter that ignores WARN level logs for netlink_proto
     let filter = EnvFilter::from_default_env()
         .add_directive(
             if args.debug {
@@ -54,8 +49,6 @@ pub fn run(args: BootArgs) -> crate::Result<()> {
     tracing::info!("Concurrent: {}", args.concurrent);
     tracing::info!("Connect timeout: {:?}s", args.connect_timeout);
 
-
-
     #[cfg(target_family = "unix")]
     {
         use nix::sys::resource::{setrlimit, Resource};
@@ -69,9 +62,8 @@ pub fn run(args: BootArgs) -> crate::Result<()> {
         concurrent: args.concurrent,
         auth,
         whitelist: args.whitelist,
-        connector: Connector::new(args.cidr, args.fallback, args.connect_timeout),
+        connector: Connector::new(args.cidr, args.fallback, args.connect_timeout,args.fixed_subnet_48),
     };
-
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .max_blocking_threads(args.concurrent)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added an example command to the documentation for running the server with a fixed IPv6 subnet.
	- Introduced an option to specify a fixed /48 subnet when launching the application, expanding network configuration capabilities.

- **Bug Fixes**
	- Enhanced the functionality related to IPv6 address assignment, ensuring correct address generation when a fixed subnet is provided.

- **Documentation**
	- Improved clarity and usability of the documentation with practical examples for server configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->