### PR TITLE
feat(extension): Add CIDR range random extension

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -85,9 +85,12 @@ pub struct BootArgs {
     /// IP addresses whitelist, e.g. 47.253.53.46,47.253.81.245
     #[clap(short, long, value_parser, value_delimiter = ',')]
     whitelist: Vec<std::net::IpAddr>,
-    /// Ip-CIDR, e.g. 2001:db8::/32
+    /// IP-CIDR, e.g. 2001:db8::/32
     #[clap(short = 'i', long)]
     cidr: Option<cidr::IpCidr>,
+    /// IP-CIDR-Range, e.g. 64
+    #[clap(short = 'r', long)]
+    cidr_range: Option<u8>,
     /// Fallback address
     #[clap(short, long)]
     fallback: Option<std::net::IpAddr>,

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -53,7 +53,6 @@ pub fn run(args: BootArgs) -> crate::Result<()> {
     tracing::info!("Version: {}", env!("CARGO_PKG_VERSION"));
     tracing::info!("Concurrent: {}", args.concurrent);
     tracing::info!("Connect timeout: {:?}s", args.connect_timeout);
-    tracing::info!("Fallback: {:?}", args.fallback);
 
     #[cfg(target_family = "unix")]
     {

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -53,8 +53,7 @@ pub fn run(args: BootArgs) -> crate::Result<()> {
     tracing::info!("Version: {}", env!("CARGO_PKG_VERSION"));
     tracing::info!("Concurrent: {}", args.concurrent);
     tracing::info!("Connect timeout: {:?}s", args.connect_timeout);
-
-
+    tracing::info!("Fallback: {:?}", args.fallback);
 
     #[cfg(target_family = "unix")]
     {
@@ -65,11 +64,16 @@ pub fn run(args: BootArgs) -> crate::Result<()> {
     }
 
     let ctx = move |auth: AuthMode| ProxyContext {
+        auth,
         bind: args.bind,
         concurrent: args.concurrent,
-        auth,
         whitelist: args.whitelist,
-        connector: Connector::new(args.cidr, args.fallback, args.connect_timeout),
+        connector: Connector::new(
+            args.cidr,
+            args.cidr_range,
+            args.fallback,
+            args.connect_timeout,
+        ),
     };
 
     tokio::runtime::Builder::new_multi_thread()


### PR DESCRIPTION
close: https://github.com/0x676e67/vproxy/issues/78

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced an optional `cidr_range` field to enhance IP configuration flexibility.
  - Added a new `Range` variant to the `Extension` enum for improved handling of range-based extensions.
  - New function for generating IPv6 addresses based on CIDR and specified range.

- **Bug Fixes**
  - Updated documentation for the `cidr` field for consistency.

- **Improvements**
  - Enhanced logging in the `run` function to better track execution parameters.
  - Improved instance initialization for the `Connector` with additional CIDR range control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->