### PR TITLE
perf: Optimize CPU performance by adjusting max_blocking_threads

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ self_update = { version = "0.42.0", default-features = false, features = [
     "compression-flate2",
 ] }
 fxhash = "0.2.1"
+num_cpus = "1.0"
 
 # for log
 tracing = "0.1.40"

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -79,10 +79,12 @@ pub fn run(args: BootArgs) -> Result<()> {
     tracing::info!("Concurrent: {}", args.concurrent);
     tracing::info!("Connect timeout: {:?}s", args.connect_timeout);
 
-    let blocking_threads = (num_cpus::get() as f64 * 1.5).round() as usize;
+    let cpu_cores = num_cpus::get();
+    let blocking_threads = (cpu_cores as f64 * 1.5).round() as usize;
 
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
+        .worker_threads(cpu_cores)
         .max_blocking_threads(blocking_threads)
         .build()?
         .block_on(async {

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -79,9 +79,11 @@ pub fn run(args: BootArgs) -> Result<()> {
     tracing::info!("Concurrent: {}", args.concurrent);
     tracing::info!("Connect timeout: {:?}s", args.connect_timeout);
 
+    let blocking_threads = (num_cpus::get() as f64 * 1.5).round() as usize;
+
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
-        .max_blocking_threads(args.concurrent)
+        .max_blocking_threads(blocking_threads)
         .build()?
         .block_on(async {
             #[cfg(target_os = "linux")]


### PR DESCRIPTION
This pull request includes changes to optimize the runtime configuration and improve performance by dynamically adjusting the number of worker and blocking threads based on the number of CPU cores available.

Performance improvements:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R30): Added `num_cpus` dependency to determine the number of CPU cores available at runtime.
* [`src/serve.rs`](diffhunk://#diff-147b0d5c968d71d81670bdb7cb8acfa58578d75b237f7e74bb76df5e9b63302bR82-R88): Modified the `run` function to calculate the number of worker threads and blocking threads based on the available CPU cores, improving the efficiency of the runtime.