### PR TITLE
perf(socks): use kernel zero-copy for TCP streams

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ sysctl = "0.7.1"
 rtnetlink = "0.18"
 netlink-packet-route = "0.25.1"
 futures = "0.3.30"
+realm_io = "0.5.3"
 
 [target.'cfg(target_family = "unix")'.dependencies]
 daemonize = "0.5.0"

--- a/src/server/socks/mod.rs
+++ b/src/server/socks/mod.rs
@@ -150,11 +150,18 @@ async fn handle_connect(
 
     match outbound {
         Ok(mut outbound) => {
-            let mut inbound = connect
+            let mut inbound: TcpStream = connect
                 .reply(Reply::Succeeded, Address::unspecified())
-                .await?;
+                .await?
+                .into();
 
-            match tokio::io::copy_bidirectional(&mut inbound, &mut outbound).await {
+            #[cfg(target_os = "linux")]
+            let res = realm_io::bidi_zero_copy(&mut inbound, &mut outbound).await;
+
+            #[cfg(not(target_os = "linux"))]
+            let res = tokio::io::copy_bidirectional(&mut inbound, &mut outbound).await;
+
+            match res {
                 Ok((from_client, from_server)) => {
                     tracing::info!(
                         "[SOCKS5][CONNECT] client wrote {} bytes and received {} bytes",


### PR DESCRIPTION
Significantly improve the performance of Linux SOCKS5 TCP forwarding. Benchmark tests show that it is on par with https://github.com/heiher/hev-socks5-server.

- vproxy

```log
$ proxychains iperf3 -c 127.0.0.1
ProxyChains-3.1 (http://proxychains.sf.net)
|S-chain|-<>-127.0.0.1:1080-<><>-127.0.0.1:5201-<><>-OK
Connecting to host 127.0.0.1, port 5201
|S-chain|-<>-127.0.0.1:1080-<><>-127.0.0.1:5201-<><>-OK
[  5] local 127.0.0.1 port 58492 connected to 127.0.0.1 port 1080
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  16.3 GBytes   140 Gbits/sec    0   1023 KBytes       
[  5]   1.00-2.01   sec  18.9 GBytes   162 Gbits/sec    0   1023 KBytes       
[  5]   2.01-3.01   sec  18.1 GBytes   156 Gbits/sec    0   1023 KBytes       
[  5]   3.01-4.00   sec  17.6 GBytes   152 Gbits/sec    0   1023 KBytes       
[  5]   4.00-5.01   sec  16.6 GBytes   142 Gbits/sec    0   1023 KBytes       
[  5]   5.01-6.01   sec  16.2 GBytes   139 Gbits/sec    1   1023 KBytes       
[  5]   6.01-7.01   sec  15.8 GBytes   135 Gbits/sec    0   1023 KBytes       
[  5]   7.01-8.01   sec  15.2 GBytes   131 Gbits/sec    0   1023 KBytes       
[  5]   8.01-9.01   sec  15.2 GBytes   131 Gbits/sec    0   1023 KBytes       
[  5]   9.01-10.01  sec  16.6 GBytes   143 Gbits/sec    0   1023 KBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.01  sec   167 GBytes   143 Gbits/sec    1            sender
[  5]   0.00-10.01  sec   167 GBytes   143 Gbits/sec                  receiver

iperf Done.
```

- hev-socks5-server

```log
$ proxychains iperf3 -c 127.0.0.1
ProxyChains-3.1 (http://proxychains.sf.net)
|S-chain|-<>-127.0.0.1:1080-<><>-127.0.0.1:5201-<><>-OK
Connecting to host 127.0.0.1, port 5201
|S-chain|-<>-127.0.0.1:1080-<><>-127.0.0.1:5201-<><>-OK
[  5] local 127.0.0.1 port 58312 connected to 127.0.0.1 port 1080
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  14.7 GBytes   126 Gbits/sec    0   2.31 MBytes       
[  5]   1.00-2.00   sec  18.9 GBytes   163 Gbits/sec    0   2.31 MBytes       
[  5]   2.00-3.00   sec  18.3 GBytes   156 Gbits/sec    0   2.31 MBytes       
[  5]   3.00-4.00   sec  18.8 GBytes   162 Gbits/sec    0   2.31 MBytes       
[  5]   4.00-5.00   sec  18.2 GBytes   156 Gbits/sec    0   2.31 MBytes       
[  5]   5.00-6.01   sec  16.8 GBytes   144 Gbits/sec    0   2.31 MBytes       
[  5]   6.01-7.00   sec  15.8 GBytes   136 Gbits/sec    0   2.31 MBytes       
[  5]   7.00-8.01   sec  18.3 GBytes   157 Gbits/sec    0   2.31 MBytes       
[  5]   8.01-9.00   sec  13.8 GBytes   119 Gbits/sec    0   2.31 MBytes       
[  5]   9.00-10.01  sec  13.3 GBytes   113 Gbits/sec    1   2.31 MBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.01  sec   167 GBytes   143 Gbits/sec    1            sender
[  5]   0.00-10.05  sec   167 GBytes   143 Gbits/sec                  receiver

iperf Done.
```