### PR TITLE
chore(server): improve access log records

### DIFF
--- a/src/server/connect.rs
+++ b/src/server/connect.rs
@@ -311,7 +311,7 @@ impl TcpConnector<'_> {
                 }
             }
             .and_then(|stream| {
-                tracing::info!("connect {} via {}", target_addr, stream.local_addr()?);
+                tracing::info!("[TCP] connect {} via {}", target_addr, stream.local_addr()?);
                 Ok(stream)
             });
 
@@ -550,15 +550,15 @@ impl UdpConnector<'_> {
         addr: SocketAddr,
         socket: &UdpSocket,
     ) -> std::io::Result<usize> {
-        socket.send_to(pkt, addr).await.inspect(|&size| {
+        socket.send_to(pkt, addr).await.and_then(|size| {
             tracing::info!(
-                "UDP packet sent to {} via {}, size: {}",
+                "[UDP] UDP packet sent to {} via {}, size: {}",
                 addr,
-                socket
-                    .local_addr()
-                    .unwrap_or_else(|_| "unknown".parse().unwrap()),
+                socket.local_addr()?,
                 size
             );
+
+            Ok(size)
         })
     }
 


### PR DESCRIPTION
This pull request enhances logging for TCP, UDP, HTTP, and SOCKS5 connection handling throughout the server codebase, making connection flows and packet forwarding more transparent and easier to debug. It also refactors some HTTP tunnel logic for clarity and maintainability.

**Logging improvements:**

* Added more descriptive and consistent log messages for TCP, UDP, HTTP, and SOCKS5 connection and forwarding events, including source and destination addresses and packet sizes. This helps track connection flows and troubleshoot issues. [[1]](diffhunk://#diff-d2f03db3bf5234cf9eb23838e7d06939248905bef7f2211b87375e078c7085e5L314-R314) [[2]](diffhunk://#diff-d2f03db3bf5234cf9eb23838e7d06939248905bef7f2211b87375e078c7085e5L553-R561) [[3]](diffhunk://#diff-a4a9cbb3818666171338e3454a1148741b9fdd15f6e4896dd2aaeb264eeec0a4L153-R169) [[4]](diffhunk://#diff-a4a9cbb3818666171338e3454a1148741b9fdd15f6e4896dd2aaeb264eeec0a4L265-R288)

**HTTP tunnel handling refactor:**

* Refactored the HTTP tunnel setup by extracting the tunnel logic into a standalone `tunnel` function, passing explicit parameters instead of relying on `self`. This improves code clarity and separation of concerns. [[1]](diffhunk://#diff-02b1f6db1d75ffd67caa853c47892a9ba23097e2ac85dd77c42ab60152054cefL253-R255) [[2]](diffhunk://#diff-02b1f6db1d75ffd67caa853c47892a9ba23097e2ac85dd77c42ab60152054cefR280-R304)
* Moved utility functions `empty` and `full` to a more appropriate location in the file for better organization. [[1]](diffhunk://#diff-02b1f6db1d75ffd67caa853c47892a9ba23097e2ac85dd77c42ab60152054cefR280-R304) [[2]](diffhunk://#diff-02b1f6db1d75ffd67caa853c47892a9ba23097e2ac85dd77c42ab60152054cefL316-L328)
* Added a missing import for `TcpConnector` in the HTTP module to support the refactored tunnel logic.